### PR TITLE
MobileFuse: add usersync info

### DIFF
--- a/static/bidder-info/mobilefuse.yaml
+++ b/static/bidder-info/mobilefuse.yaml
@@ -16,3 +16,10 @@ endpointCompression: "GZIP"
 openrtb:
   version: 2.6
   gpp-supported: true
+userSync:
+  iframe:
+    url: "https://mfx.mobilefuse.com/usync?us_privacy={{.USPrivacy}}&pxurl={{.RedirectURL}}"
+    userMacro: "$UID"
+  redirect:
+    url: "https://mfx.mobilefuse.com/getuid?us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "$UID"


### PR DESCRIPTION
MobileFuse now supports a user sync. This PR adds the usersync config to mobilefuse.yaml.

Related PR: https://github.com/mobilefuse/Prebid.js/pull/1